### PR TITLE
Revert "Revert "Add runtime dependencies for net-ssh""

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,8 @@ PATH
   remote: .
   specs:
     devbox_launcher (0.1.0)
+      bcrypt_pbkdf
+      ed25519
       ghost
       net-ssh
       thor
@@ -9,9 +11,11 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    bcrypt_pbkdf (1.0.1)
     byebug (11.0.1)
     coderay (1.1.2)
     diff-lcs (1.3)
+    ed25519 (1.2.4)
     ghost (1.0.0)
       unindent (= 1.0)
     method_source (0.9.2)

--- a/devbox_launcher.gemspec
+++ b/devbox_launcher.gemspec
@@ -34,4 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "thor"
   spec.add_runtime_dependency "ghost"
   spec.add_runtime_dependency "net-ssh"
+  spec.add_runtime_dependency "ed25519"
+  spec.add_runtime_dependency "bcrypt_pbkdf"
 end


### PR DESCRIPTION
Reverts bloom-solutions/devbox_launcher#3

Fixes:

/Users/ramon/.rvm/gems/ruby-2.6.3/gems/net-ssh-5.2.0/lib/net/ssh/authentication/ed25519_loader.rb:21:in `raiseUnlessLoaded': OpenSSH keys only supported if ED25519 is available (NotImplementedError)
net-ssh requires the following gems for ed25519 support:
 * ed25519 (>= 1.2, < 2.0)
 * bcrypt_pbkdf (>= 1.0, < 2.0)
See https://github.com/net-ssh/net-ssh/issues/565 for more information
Gem::LoadError : "ed25519 is not part of the bundle. Add it to your Gemfile."