### PR TITLE
Lessen Linux CPU burn when mutagen is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Label sessions with devbox
+
+## [0.2.0]
 ### Added
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Label sessions with devbox
+- On linux, mutagen relies on watchman to detect changes
+
+### Fixed
+- In Linux, mutagen no longer burns CPU every 10 seconds
 
 ## [0.2.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0]
 ### Changed
 - Label sessions with devbox
 - On linux, mutagen relies on watchman to detect changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devbox_launcher (0.2.0)
+    devbox_launcher (0.3.0)
       activesupport (~> 6.0)
       bcrypt_pbkdf (~> 1.0)
       ed25519 (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,8 @@ PATH
       bcrypt_pbkdf (~> 1.0)
       ed25519 (~> 1.2)
       net-ssh (~> 5.2)
+      os (~> 1.0)
+      ruby-watchman (= 0.0.2)
       ssh-config (= 0.1.3)
       thor (~> 1.0)
 
@@ -22,7 +24,6 @@ GEM
     byebug (11.0.1)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
-    deep_fetch (0.0.5)
     diff-lcs (1.3)
     ed25519 (1.2.4)
     i18n (1.8.2)
@@ -30,6 +31,7 @@ GEM
     method_source (0.9.2)
     minitest (5.14.0)
     net-ssh (5.2.0)
+    os (1.0.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -50,6 +52,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
+    ruby-watchman (0.0.2)
     ssh-config (0.1.3)
     thor (1.0.1)
     thread_safe (0.3.6)
@@ -68,4 +71,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/devbox_launcher.gemspec
+++ b/devbox_launcher.gemspec
@@ -39,4 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "bcrypt_pbkdf", "~> 1.0"
   spec.add_runtime_dependency "ssh-config", "0.1.3"
   spec.add_runtime_dependency "activesupport", "~> 6.0"
+  spec.add_runtime_dependency "os", "~> 1.0"
+  spec.add_runtime_dependency "ruby-watchman", "0.0.2"
 end

--- a/lib/devbox_launcher.rb
+++ b/lib/devbox_launcher.rb
@@ -3,6 +3,10 @@ require "ssh-config"
 require "open3"
 require "thor"
 require "net/ssh"
+require "os"
+require "ruby-watchman"
+require 'socket'
+require 'pathname'
 require "yaml"
 require "devbox_launcher/version"
 
@@ -11,3 +15,4 @@ module DevboxLauncher
 end
 
 require "devbox_launcher/cli"
+require "devbox_launcher/watchman"

--- a/lib/devbox_launcher/cli.rb
+++ b/lib/devbox_launcher/cli.rb
@@ -104,7 +104,8 @@ module DevboxLauncher
         return if alpha_dir.nil? || beta_dir.nil?
 
         puts "Terminating all mutagen sessions..."
-        terminate_mutagen_command = %Q(mutagen terminate --all)
+        terminate_mutagen_command =
+          %Q(mutagen terminate --label-selector=devbox)
         terminate_mutagen_stdout,
           terminate_mutagen_stderr,
           terminate_mutagen_status =
@@ -124,6 +125,7 @@ module DevboxLauncher
           "mutagen sync create",
           alpha_dir,
           "#{hostname}:#{beta_dir}",
+          "--label=devbox",
         ].join(" ")
         create_mutagen_stdout,
           create_mutagen_stderr,

--- a/lib/devbox_launcher/cli.rb
+++ b/lib/devbox_launcher/cli.rb
@@ -6,6 +6,7 @@ module DevboxLauncher
     SSH_CONFIG_PATH = File.expand_path("~/.ssh/config").freeze
     CONFIG_PATH = File.expand_path("~/.devbox_launcher.yml").freeze
     CONFIG = YAML.load_file(CONFIG_PATH).freeze
+    LABEL = "devbox".freeze
 
     desc "start configured box for account", "Start a devbox by account"
     option :mosh, type: :boolean, desc: "Mosh in"
@@ -103,9 +104,22 @@ module DevboxLauncher
 
         return if alpha_dir.nil? || beta_dir.nil?
 
-        puts "Terminating all mutagen sessions..."
+        terminate_mutagen_session
+        create_mutagen_session(
+          alpha_dir: alpha_dir,
+          beta_dir: beta_dir,
+          hostname: hostname,
+        )
+
+        if OS.linux?
+          watch_alpha(alpha_dir: alpha_dir)
+        end
+      end
+
+      def terminate_mutagen_session
+        puts "Terminating mutagen session..."
         terminate_mutagen_command =
-          %Q(mutagen terminate --label-selector=devbox)
+          %Q(mutagen terminate --label-selector=#{LABEL})
         terminate_mutagen_stdout,
           terminate_mutagen_stderr,
           terminate_mutagen_status =
@@ -118,19 +132,24 @@ module DevboxLauncher
             "#{terminate_mutagen_stderr}"
           fail msg
         end
+      end
 
+      def create_mutagen_session(alpha_dir:, beta_dir:, hostname:)
         puts "Create mutagen session syncing local #{alpha_dir} " \
           "with #{hostname} #{beta_dir}"
+
         create_mutagen_command = [
           "mutagen sync create",
           alpha_dir,
           "#{hostname}:#{beta_dir}",
-          "--label=devbox",
-        ].join(" ")
+          "--label=#{LABEL}",
+        ]
+        create_mutagen_command << "--watch-mode-alpha=no-watch" if OS.linux?
+
         create_mutagen_stdout,
           create_mutagen_stderr,
           create_mutagen_status =
-          Open3.capture3(create_mutagen_command)
+          Open3.capture3(create_mutagen_command.join(" "))
 
         if not create_mutagen_status.success?
           # mutagen prints to stdout and stderr
@@ -139,6 +158,11 @@ module DevboxLauncher
             "#{create_mutagen_stderr}"
           fail msg
         end
+      end
+
+      def watch_alpha(alpha_dir:)
+        watchman = Watchman.new(dir: alpha_dir)
+        watchman.trigger("mutagen sync flush --label-selector=#{LABEL}")
       end
     end
 

--- a/lib/devbox_launcher/version.rb
+++ b/lib/devbox_launcher/version.rb
@@ -1,3 +1,3 @@
 module DevboxLauncher
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/lib/devbox_launcher/watchman.rb
+++ b/lib/devbox_launcher/watchman.rb
@@ -1,0 +1,50 @@
+module DevboxLauncher
+  class Watchman
+
+    attr_reader :dir
+
+    def initialize(dir:)
+      @dir = dir
+    end
+
+    def trigger(command)
+      UNIXSocket.open(sockname) do |socket|
+        root = Pathname.new(dir).expand_path.to_s
+        result = RubyWatchman.query(['watch-list'], socket)
+        roots = result['roots']
+        if !roots.include?(root)
+          # this path isn't being watched yet; try to set up watch
+          result = RubyWatchman.query(['watch-project', root], socket)
+
+          # root_restrict_files setting may prevent Watchman from working
+          raise "Unable to watch #{dir}" if result.has_key?('error')
+        end
+
+        query = ['trigger', root, {
+          'name' => 'mutagen-sync',
+          'expression' => ['match', '**/*', 'wholename'],
+          'command' => command.split(" "),
+        }]
+        paths = RubyWatchman.query(query, socket)
+
+        # could return error if watch is removed
+        if paths.has_key?('error')
+          raise "Unable to set trigger. Error: #{paths['error']}"
+        end
+      end
+    end
+
+    def sockname
+      sockname = RubyWatchman.load(
+        %x{watchman --output-encoding=bser get-sockname}
+      )['sockname']
+
+      if !$?.exitstatus.zero?
+        raise "Failed to connect to watchman. Is it running?"
+      end
+
+      sockname
+    end
+
+  end
+end


### PR DESCRIPTION
Let watchman flush the session since Linux does not provide an optimal way to watch changes. This change only affects Linux hosts (your physical development machine).